### PR TITLE
add method: Uniform Risk Minimization (URM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The [currently available algorithms](./subpopbench/learning/algorithms.py) are:
 * Label-Distribution-Aware Margin Loss (**LDAM**, [Cao et al., 2019](https://arxiv.org/abs/1906.07413))
 * Balanced Softmax (**BSoftmax**, [Ren et al., 2020](https://arxiv.org/abs/2007.10740))
 * Classifier Re-Training (**CRT**, [Kang et al., 2020](https://arxiv.org/abs/1910.09217))
+* Uniform Risk Minimization (**URM**, [Krishnamachari et al., 2024](https://openreview.net/forum?id=PgLbS5yp8n))
 
 Send us a PR to add your algorithm! Our implementations use the hyper-parameter grids [described here](./subpopbench/hparams_registry.py).
 

--- a/subpopbench/hparams_registry.py
+++ b/subpopbench/hparams_registry.py
@@ -89,6 +89,23 @@ def _hparams(algorithm, dataset, random_seed):
         _hparam('stage1_model', 'model.pkl', lambda r: 'model.pkl')
         _hparam('dfr_reg', .1, lambda r: 10**r.uniform(-2, 0.5))
 
+    elif algorithm == 'URM':
+        _hparam('urm_lambda', 0.1, lambda r: float(r.uniform(0,0.2)))
+        
+        _hparam('urm_discriminator_hidden_layers', 1, lambda r: int(r.choice([1,2,3])))
+        _hparam('urm_generator_output', 'tanh', lambda r: str(r.choice(['tanh', 'relu'])))
+        _hparam('urm_discriminator_update_freq', 1, lambda r: int(r.choice([1])))
+        
+        if dataset in IMAGE_DATASETS + TABULAR_DATASET:
+            _hparam('urm_discriminator_lr', 1e-3, lambda r: 10**r.uniform(-5, -3))
+        else:
+            _hparam('urm_discriminator_lr', 1e-5, lambda r: 10**r.uniform(-6, -5))
+    
+        if dataset in TEXT_DATASETS:
+            _hparam('urm_discriminator_optimizer', 'adamw', lambda r: str(r.choice(['adamw'])))
+        else:
+            _hparam('urm_discriminator_optimizer', 'sgd', lambda r: str(r.choice(['sgd'])))
+
     # Dataset-and-algorithm-specific hparam definitions
     # Each block of code below corresponds to exactly one hparam. Avoid nested conditionals
 

--- a/subpopbench/learning/algorithms.py
+++ b/subpopbench/learning/algorithms.py
@@ -189,8 +189,6 @@ class URM(ERM):
 
         if self.hparams['urm_generator_output'] == 'tanh':
             if self.data_type == 'images' and self.hparams['image_arch'] == 'resnet_sup_in1k':
-                # self.featurizer.network.layer4[0].relu = nn.Tanh()
-                # self.featurizer.network.layer4[1].relu = nn.Tanh()
                 self.featurizer.network.layer4[2].relu = nn.Tanh()
                 
             elif self.data_type == 'text' and self.hparams['text_arch'] == 'bert-base-uncased':


### PR DESCRIPTION
I am first author of "Uniformly Distributed Feature Representations for Fair and Robust Learning" (TMLR 2024) paper. Link: https://openreview.net/forum?id=PgLbS5yp8n

In this pull request I am adding code for the proposed Uniform Risk Minimization (URM) method for subpopulation robustness. The key idea is to encourage the distribution of feature representations learned by the encoder/featurizer to be uniformly distributed. The paper provides theoretical and empirical support for the proposed method in sub-population robustness and also domain generalization.

Changes include:

-  added `URM` class in `algorithms.py`
- added hyper-parameters in `hparams_registry.py`
- modified `networks.py` and `lib/wide_resnet.py` to add an activation function to the output of the featurizer/encoder networks (before the linear classifier). This does not affect other algorithms in SubpopBench as the default activation is nn.Identity(): https://github.com/kiranchari/SubpopBench/blob/198ea9548948b5af0a084798878c880e89d248d6/subpopbench/models/networks.py#L31
- added method and link to paper in `README.md`

Thank you.